### PR TITLE
Refactor FibonacciKtTest to not use single-expression function

### DIFF
--- a/src/fibonacci-worker/src/test/kotlin/de/envite/greenbpm/camunda_process_carbon_pricing/fibonacci_worker/FibonacciKtTest.kt
+++ b/src/fibonacci-worker/src/test/kotlin/de/envite/greenbpm/camunda_process_carbon_pricing/fibonacci_worker/FibonacciKtTest.kt
@@ -8,7 +8,9 @@ import org.junit.jupiter.params.provider.MethodSource
 class FibonacciKtTest {
     @ParameterizedTest(name = "For {0}, the Fibonacci is {1}")
     @MethodSource("getData")
-    fun `should return correct fibonacci values`(input: Int, expected: Int) = fibonacciRec(input) shouldBe expected
+    fun `should return correct fibonacci values`(input: Int, expected: Int) {
+        fibonacciRec(input) shouldBe expected
+    }
 
     companion object{
         @JvmStatic


### PR DESCRIPTION
For some reason, when the test was written with a single-expression function, it was not interpreted as a test:

<img width="1064" alt="Bildschirmfoto 2024-09-06 um 15 52 06" src="https://github.com/user-attachments/assets/3a564f80-c846-428e-9cf2-540d0f6b22de">

After refactoring with curly braces, the test works as expected:

<img width="1064" alt="Bildschirmfoto 2024-09-06 um 15 52 46" src="https://github.com/user-attachments/assets/ecdcabc1-1b6e-4d1a-9694-e40dfc73827f">

If you have an explanation for that, or if you know how to make the test work with single-expression function, you can ignore this PR!